### PR TITLE
Updating Firewheel.java

### DIFF
--- a/core/src/com/projectkorra/projectkorra/firebending/combo/FireWheel.java
+++ b/core/src/com/projectkorra/projectkorra/firebending/combo/FireWheel.java
@@ -44,6 +44,7 @@ public class FireWheel extends FireAbility implements ComboAbility {
 	private double damage;
 	private ArrayList<LivingEntity> affectedEntities;
 
+
 	public FireWheel(final Player player) {
 		super(player);
 
@@ -130,7 +131,7 @@ public class FireWheel extends FireAbility implements ComboAbility {
 			emitFirebendingLight(tempLoc);
 		}
 
-		for (final Entity entity : GeneralMethods.getEntitiesAroundPoint(this.location, this.radius + 0.5)) {
+		for (final Entity entity : GeneralMethods.getEntitiesAroundPoint(this.location, this.radius * 0.2)) {
 			if (entity instanceof LivingEntity && !entity.equals(this.player)) {
 				if (!this.affectedEntities.contains(entity)) {
 					this.affectedEntities.add((LivingEntity) entity);


### PR DESCRIPTION
Decreased the radius multiplier to 0.2. (Removing the multiplier / add makes the range true to the hitbox, however the collisions are a bit weird -- sometimes it misses when the player is diagonal. 0.2 is just there as a little buffer)